### PR TITLE
fix: add missing ambrrm struct

### DIFF
--- a/models/model_ambr_rm.go
+++ b/models/model_ambr_rm.go
@@ -13,4 +13,8 @@
 package models
 
 type AmbrRm struct {
+	// String representing a bit rate; the prefixes follow the standard symbols from The International System of Units, and represent x1000 multipliers, with the exception that prefix \"K\" is used to represent the standard symbol \"k\".
+	Uplink string `json:"uplink" yaml:"uplink" bson:"uplink,omitempty"`
+	// String representing a bit rate; the prefixes follow the standard symbols from The International System of Units, and represent x1000 multipliers, with the exception that prefix \"K\" is used to represent the standard symbol \"k\".
+	Downlink string `json:"downlink" yaml:"downlink" bson:"downlink,omitempty"`
 }


### PR DESCRIPTION
In TS29503 SubsrcibedUeAmbr's data type is ambrrm
![image](https://github.com/user-attachments/assets/fc6066c7-496c-4d69-853d-e8bcacdb1a68)

In TS29571
ambrrm's struct is same as ambr 
![image](https://github.com/user-attachments/assets/fdfc79f0-a0e8-4f28-b840-0f53900489eb)

but  in openapi feat/r17  model/model_ambr_rm.go ambrrm is missing 
![image](https://github.com/user-attachments/assets/8f74bc5c-1be9-4e3f-9e6e-8349eff7d2d1)
