### PR TITLE
fix: missing modify subscription request

### DIFF
--- a/models/model_modify_subscription_request.go
+++ b/models/model_modify_subscription_request.go
@@ -13,4 +13,6 @@
 package models
 
 type ModifySubscriptionRequest struct {
+	SubscriptionItem []AmfUpdateEventSubscriptionItem
+	OptionItem       []AmfUpdateEventOptionItem
 }


### PR DESCRIPTION
## Description
In the TS 29.518 api_event, the modification involves `AmfUpdateEventSubscriptionItem` or `AmfUpdateEventOptionItem`. 

Neither the R15 nor the R17 specifications define the `ModifySubscriptionRequest` data type. 

When referring to the R15 version of the OpenAPI, the request data encapsulates them into the request.

- TS29.518 V17.12 p62
![image](https://github.com/user-attachments/assets/93f9606b-8299-40d3-b1e7-4551c9c84d3a)

- TS29.518 V17.12 p211
![image](https://github.com/user-attachments/assets/aed90ae2-f487-4a0d-94ab-4f462f19efe4)

## Reference from R15.
- In TS29 518 V15.2 p103
![image](https://github.com/user-attachments/assets/0b848ee6-35a5-4a5c-b9c1-40092131e80f)
- openapi main (R15)
![image](https://github.com/user-attachments/assets/71dd1feb-9577-4fd4-96df-5ee76f2d1ef5)


