### PR TITLE
fix: GetSmData Responce type

### DIFF
--- a/udm/SubscriberDataManagement/api_session_management_subscription_data_retrieval.go
+++ b/udm/SubscriberDataManagement/api_session_management_subscription_data_retrieval.go
@@ -80,7 +80,7 @@ type GetSmDataResponse struct {
 	CacheControl string
 	ETag         string
 	LastModified string
-	SmSubsData   models.SmSubsData
+	SmSubsData   []models.SessionManagementSubscriptionData
 }
 
 type GetSmDataError struct {


### PR DESCRIPTION
- Spec: TS29.502 
<img width="947" alt="截圖 2024-10-24 下午3 47 41" src="https://github.com/user-attachments/assets/fcd8a525-ba87-449c-b59a-ab00f5e02830">

### => Response type shold be `[]models.SessionManagementSubscriptionData`


```yaml
responses:
  '200':
    description: Expected response to a valid request
    content:
            application/json:
                schema:
                    type: array
                    items:
                      $ref: '#/components/schemas/SessionManagementSubscriptionData'
                    minItems: 1
```


- Spec screenshot 

<img width="1050" alt="截圖 2024-10-24 下午3 39 30" src="https://github.com/user-attachments/assets/2df7d090-05cc-40ab-a5c7-99f749940b95">


<img width="878" alt="截圖 2024-10-24 下午3 40 00" src="https://github.com/user-attachments/assets/bbe4a097-d4e8-4427-b6c9-29062a5434cc">
