### PR TITLE
fix: modify type AccNetChId and SessionRuleReport

### DIFF
--- a/models/model_acc_net_ch_id.go
+++ b/models/model_acc_net_ch_id.go
@@ -17,7 +17,7 @@ type AccNetChId struct {
 	// Integer where the allowed values correspond to the value range of an unsigned 32-bit integer.
 	AccNetChaIdValue int32 `json:"accNetChaIdValue,omitempty" yaml:"accNetChaIdValue" bson:"accNetChaIdValue,omitempty"`
 	// A character string containing the access network charging id.
-	AccNetChargId string `json:"accNetChargId,omitempty" yaml:"accNetChargId" bson:"accNetChargId,omitempty"`
+	AccNetChargId string `json:"accNetChargIdString,omitempty" yaml:"accNetChargId" bson:"accNetChargId,omitempty"`
 	// Contains the identifier of the PCC rule(s) associated to the provided Access Network Charging Identifier.
 	RefPccRuleIds []string `json:"refPccRuleIds,omitempty" yaml:"refPccRuleIds" bson:"refPccRuleIds,omitempty"`
 	// When it is included and set to true, indicates the Access Network Charging Identifier applies to the whole PDU Session

--- a/models/model_session_rule_report.go
+++ b/models/model_session_rule_report.go
@@ -18,6 +18,4 @@ type SessionRuleReport struct {
 	RuleIds             []string               `json:"ruleIds" yaml:"ruleIds" bson:"ruleIds,omitempty"`
 	RuleStatus          RuleStatus             `json:"ruleStatus" yaml:"ruleStatus" bson:"ruleStatus,omitempty"`
 	SessRuleFailureCode SessionRuleFailureCode `json:"sessRuleFailureCode,omitempty" yaml:"sessRuleFailureCode" bson:"sessRuleFailureCode,omitempty"`
-	// Contains the type(s) of failed policy decision and/or condition data.
-	PolicyDecFailureReports []PolicyDecisionFailureCode `json:"policyDecFailureReports,omitempty" yaml:"policyDecFailureReports" bson:"policyDecFailureReports,omitempty"`
 }


### PR DESCRIPTION
Based on TS 29.512 V17.11,

type **SessionRuleReport** should be defined as follow : 

![image](https://github.com/user-attachments/assets/674a1267-958c-4827-9ed9-adcae6e7f71f)

type **AccNetChId** should be defined as follow : 

![image](https://github.com/user-attachments/assets/26d8c5c1-1494-49e7-9c12-8ec3e9662eb2)
