### PR TITLE
feat: add outbout metrics hook system

### DIFF
--- a/amf/Communication/configuration.go
+++ b/amf/Communication/configuration.go
@@ -13,6 +13,7 @@
 package Communication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-comm/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/amf/EventExposure/configuration.go
+++ b/amf/EventExposure/configuration.go
@@ -13,6 +13,7 @@
 package EventExposure
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-evts/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/amf/Location/configuration.go
+++ b/amf/Location/configuration.go
@@ -13,6 +13,7 @@
 package Location
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-loc/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/amf/MBSBroadcast/configuration.go
+++ b/amf/MBSBroadcast/configuration.go
@@ -13,6 +13,7 @@
 package MBSBroadcast
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-mbs-bc/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/amf/MBSCommunication/configuration.go
+++ b/amf/MBSCommunication/configuration.go
@@ -13,6 +13,7 @@
 package MBSCommunication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-mbs-comm/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/amf/MT/configuration.go
+++ b/amf/MT/configuration.go
@@ -13,6 +13,7 @@
 package MT
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/namf-mt/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/ausf/SoRProtection/configuration.go
+++ b/ausf/SoRProtection/configuration.go
@@ -13,6 +13,7 @@
 package SoRProtection
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nausf-sorprotection/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/ausf/UEAuthentication/configuration.go
+++ b/ausf/UEAuthentication/configuration.go
@@ -13,6 +13,7 @@
 package UEAuthentication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nausf-auth/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/ausf/UPUProtection/configuration.go
+++ b/ausf/UPUProtection/configuration.go
@@ -13,6 +13,7 @@
 package UPUProtection
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nausf-upuprotection/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/bsf/Management/configuration.go
+++ b/bsf/Management/configuration.go
@@ -13,6 +13,7 @@
 package Management
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nbsf-management/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/chf/ConvergedCharging/configuration.go
+++ b/chf/ConvergedCharging/configuration.go
@@ -13,6 +13,7 @@
 package ConvergedCharging
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nchf-convergedcharging/v3",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/chf/OfflineOnlyCharging/configuration.go
+++ b/chf/OfflineOnlyCharging/configuration.go
@@ -13,6 +13,7 @@
 package OfflineOnlyCharging
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nchf-offlineonlycharging/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/chf/SpendingLimitControl/configuration.go
+++ b/chf/SpendingLimitControl/configuration.go
@@ -13,6 +13,7 @@
 package SpendingLimitControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nchf-spendinglimitcontrol/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/lmf/Broadcast/configuration.go
+++ b/lmf/Broadcast/configuration.go
@@ -13,6 +13,7 @@
 package Broadcast
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nlmf-broadcast/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/lmf/Location/configuration.go
+++ b/lmf/Location/configuration.go
@@ -13,6 +13,7 @@
 package Location
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nlmf-loc/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,13 @@
+package openapi
+
+// RequestMetricsHook is called after each HTTP Submit.
+//
+//	method:       HTTP method (GET, POST, ...)
+//	path:         URL path pattern (e.g. "/namf-comm/v1/...")
+//	status:       HTTP status code (0 if no response)
+type RequestMetricsHook func(
+	method string,
+	path string,
+	status int,
+	duration float64,
+)

--- a/nef/AsSessionWithQoS/configuration.go
+++ b/nef/AsSessionWithQoS/configuration.go
@@ -13,6 +13,7 @@
 package AsSessionWithQoS
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/3gpp-as-session-with-qos/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/Authentication/configuration.go
+++ b/nef/Authentication/configuration.go
@@ -13,6 +13,7 @@
 package Authentication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-authentication/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/EASDeployment/configuration.go
+++ b/nef/EASDeployment/configuration.go
@@ -13,6 +13,7 @@
 package EASDeployment
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-eas-deployment/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/EventExposure/configuration.go
+++ b/nef/EventExposure/configuration.go
@@ -13,6 +13,7 @@
 package EventExposure
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-eventexposure/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/PFDmanagement/configuration.go
+++ b/nef/PFDmanagement/configuration.go
@@ -13,6 +13,7 @@
 package PFDmanagement
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-pfdmanagement/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/SMContext/configuration.go
+++ b/nef/SMContext/configuration.go
@@ -13,6 +13,7 @@
 package SMContext
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-smcontext/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/SMService/configuration.go
+++ b/nef/SMService/configuration.go
@@ -13,6 +13,7 @@
 package SMService
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnef-smservice/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nef/TrafficInfluence/configuration.go
+++ b/nef/TrafficInfluence/configuration.go
@@ -13,6 +13,7 @@
 package TrafficInfluence
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/3gpp-traffic-influence/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nrf/AccessToken/configuration.go
+++ b/nrf/AccessToken/configuration.go
@@ -13,6 +13,7 @@
 package AccessToken
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nrf/Bootstrapping/configuration.go
+++ b/nrf/Bootstrapping/configuration.go
@@ -13,6 +13,7 @@
 package Bootstrapping
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nrf/NFDiscovery/configuration.go
+++ b/nrf/NFDiscovery/configuration.go
@@ -13,6 +13,7 @@
 package NFDiscovery
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnrf-disc/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nrf/NFManagement/configuration.go
+++ b/nrf/NFManagement/configuration.go
@@ -13,6 +13,7 @@
 package NFManagement
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnrf-nfm/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nssf/NSSAIAvailability/configuration.go
+++ b/nssf/NSSAIAvailability/configuration.go
@@ -13,6 +13,7 @@
 package NSSAIAvailability
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnssf-nssaiavailability/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nssf/NSSelection/configuration.go
+++ b/nssf/NSSelection/configuration.go
@@ -13,6 +13,7 @@
 package NSSelection
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnssf-nsselection/v2",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nwdaf/AnalyticsInfo/configuration.go
+++ b/nwdaf/AnalyticsInfo/configuration.go
@@ -13,6 +13,7 @@
 package AnalyticsInfo
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnwdaf-analyticsinfo/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nwdaf/DataManagement/configuration.go
+++ b/nwdaf/DataManagement/configuration.go
@@ -13,6 +13,7 @@
 package DataManagement
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnwdaf-datamanagement/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nwdaf/EventsSubscription/configuration.go
+++ b/nwdaf/EventsSubscription/configuration.go
@@ -13,6 +13,7 @@
 package EventsSubscription
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnwdaf-eventssubscription/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/nwdaf/MLModelProvision/configuration.go
+++ b/nwdaf/MLModelProvision/configuration.go
@@ -13,6 +13,7 @@
 package MLModelProvision
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nnwdaf-mlmodelprovision/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/AMPolicyAuthorization/configuration.go
+++ b/pcf/AMPolicyAuthorization/configuration.go
@@ -13,6 +13,7 @@
 package AMPolicyAuthorization
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-am-policyauthorization/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/AMPolicyControl/configuration.go
+++ b/pcf/AMPolicyControl/configuration.go
@@ -13,6 +13,7 @@
 package AMPolicyControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-am-policy-control/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/BDTPolicyControl/configuration.go
+++ b/pcf/BDTPolicyControl/configuration.go
@@ -13,6 +13,7 @@
 package BDTPolicyControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-bdtpolicycontrol/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/EventExposure/configuration.go
+++ b/pcf/EventExposure/configuration.go
@@ -13,6 +13,7 @@
 package EventExposure
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-eventexposure/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return nil
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/MBSPolicyAuthorization/configuration.go
+++ b/pcf/MBSPolicyAuthorization/configuration.go
@@ -13,6 +13,7 @@
 package MBSPolicyAuthorization
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-mbspolicyauth/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/MBSPolicyControl/configuration.go
+++ b/pcf/MBSPolicyControl/configuration.go
@@ -13,6 +13,7 @@
 package MBSPolicyControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-mbspolicycontrol/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/PolicyAuthorization/configuration.go
+++ b/pcf/PolicyAuthorization/configuration.go
@@ -13,6 +13,7 @@
 package PolicyAuthorization
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-policyauthorization/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/SMPolicyControl/configuration.go
+++ b/pcf/SMPolicyControl/configuration.go
@@ -13,6 +13,7 @@
 package SMPolicyControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-smpolicycontrol/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/pcf/UEPolicyControl/configuration.go
+++ b/pcf/UEPolicyControl/configuration.go
@@ -13,6 +13,7 @@
 package UEPolicyControl
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/npcf-ue-policy-control/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/smf/EventExposure/configuration.go
+++ b/smf/EventExposure/configuration.go
@@ -13,6 +13,7 @@
 package EventExposure
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nsmf-event-exposure/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/smf/NIDD/configuration.go
+++ b/smf/NIDD/configuration.go
@@ -13,6 +13,7 @@
 package NIDD
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nsmf-nidd/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/smf/PDUSession/configuration.go
+++ b/smf/PDUSession/configuration.go
@@ -13,6 +13,7 @@
 package PDUSession
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nsmf-pdusession/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/EventExposure/configuration.go
+++ b/udm/EventExposure/configuration.go
@@ -13,6 +13,7 @@
 package EventExposure
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-ee/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/MT/configuration.go
+++ b/udm/MT/configuration.go
@@ -13,6 +13,7 @@
 package MT
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-mt/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/NIDDAuthentication/configuration.go
+++ b/udm/NIDDAuthentication/configuration.go
@@ -13,6 +13,7 @@
 package NIDDAuthentication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-niddau/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/ParameterProvision/configuration.go
+++ b/udm/ParameterProvision/configuration.go
@@ -13,6 +13,7 @@
 package ParameterProvision
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-pp/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/ReportSMDeliveryStatus/configuration.go
+++ b/udm/ReportSMDeliveryStatus/configuration.go
@@ -13,6 +13,7 @@
 package ReportSMDeliveryStatus
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-rsds/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/ServiceSpecificAuthorization/configuration.go
+++ b/udm/ServiceSpecificAuthorization/configuration.go
@@ -13,6 +13,7 @@
 package ServiceSpecificAuthorization
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-ssau/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/SubscriberDataManagement/configuration.go
+++ b/udm/SubscriberDataManagement/configuration.go
@@ -13,6 +13,7 @@
 package SubscriberDataManagement
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-sdm/v2",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/UEAuthentication/configuration.go
+++ b/udm/UEAuthentication/configuration.go
@@ -13,6 +13,7 @@
 package UEAuthentication
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-ueau/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/UEContextManagement/configuration.go
+++ b/udm/UEContextManagement/configuration.go
@@ -13,6 +13,7 @@
 package UEContextManagement
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-uecm/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udm/UEID/configuration.go
+++ b/udm/UEID/configuration.go
@@ -13,6 +13,7 @@
 package UEID
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudm-ueid/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udr/DataRepository/configuration.go
+++ b/udr/DataRepository/configuration.go
@@ -13,6 +13,7 @@
 package DataRepository
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudr-dr/v2",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udr/GroupIDmap/configuration.go
+++ b/udr/GroupIDmap/configuration.go
@@ -13,6 +13,7 @@
 package GroupIDmap
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudr-group-id-map/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udr/ImsDataRepository/configuration.go
+++ b/udr/ImsDataRepository/configuration.go
@@ -1,7 +1,7 @@
 /*
  * Nudr_DataRepository API OpenAPI file
  *
- * Unified Data Repository Service.   © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).   All rights reserved. 
+ * Unified Data Repository Service.   © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).   All rights reserved.
  *
  * Source file: 3GPP TS 29.504 V18.3.0; 5G System; Unified Data Repository Services; Stage 3
  * Url: https://www.3gpp.org/ftp/Specs/archive/29_series/29.504/
@@ -13,66 +13,77 @@
 package ImsDataRepository
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
-    "strings"
+	"strings"
 )
 
 type Configuration struct {
-    url           string
-    basePath      string
-    host          string
-    defaultHeader map[string]string
-    userAgent     string
-    httpClient    *http.Client
+	url           string
+	basePath      string
+	host          string
+	defaultHeader map[string]string
+	userAgent     string
+	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-        basePath:      "https://example.com/nudr-ims-dr/v1",
+		basePath:      "https://example.com/nudr-ims-dr/v1",
 		url:           "{apiRoot}/nudr-ims-dr/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
 
 func (c *Configuration) SetBasePath(apiRoot string) {
-    url := c.url
+	url := c.url
 
-    // Replace apiRoot
-    url = strings.Replace(url, "{"+"apiRoot"+"}", apiRoot, -1)
+	// Replace apiRoot
+	url = strings.Replace(url, "{"+"apiRoot"+"}", apiRoot, -1)
 
-    c.basePath = url
+	c.basePath = url
 }
 
 func (c *Configuration) BasePath() string {
-    return c.basePath
+	return c.basePath
 }
 
 func (c *Configuration) Host() string {
-    return c.host
+	return c.host
 }
 
 func (c *Configuration) SetHost(host string) {
-    c.host = host
+	c.host = host
 }
 
 func (c *Configuration) UserAgent() string {
-    return c.userAgent
+	return c.userAgent
 }
 
 func (c *Configuration) SetUserAgent(userAgent string) {
-    c.userAgent = userAgent
+	c.userAgent = userAgent
 }
 
 func (c *Configuration) DefaultHeader() map[string]string {
-    return c.defaultHeader
+	return c.defaultHeader
 }
 
 func (c *Configuration) AddDefaultHeader(key string, value string) {
-    c.defaultHeader[key] = value
+	c.defaultHeader[key] = value
 }
 
 func (c *Configuration) HTTPClient() *http.Client {
-return c.httpClient
+	return c.httpClient
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udsf/DataRepository/configuration.go
+++ b/udsf/DataRepository/configuration.go
@@ -13,6 +13,7 @@
 package DataRepository
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudsf-dr/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/udsf/Timer/configuration.go
+++ b/udsf/Timer/configuration.go
@@ -13,6 +13,7 @@
 package Timer
 
 import (
+	"github.com/free5gc/openapi"
 	"net/http"
 	"strings"
 )
@@ -24,6 +25,7 @@ type Configuration struct {
 	defaultHeader map[string]string
 	userAgent     string
 	httpClient    *http.Client
+	MetricsHook   openapi.RequestMetricsHook
 }
 
 func NewConfiguration() *Configuration {
@@ -32,6 +34,7 @@ func NewConfiguration() *Configuration {
 		url:           "{apiRoot}/nudsf-timer/v1",
 		defaultHeader: make(map[string]string),
 		userAgent:     "OpenAPI-Generator/1.0.0/go",
+		MetricsHook:   nil, // no-op unless the caller sets it
 	}
 	return cfg
 }
@@ -79,4 +82,12 @@ func (c *Configuration) HTTPClient() *http.Client {
 
 func (c *Configuration) SetHTTPClient(client *http.Client) {
 	c.httpClient = client
+}
+
+func (c *Configuration) Metrics() openapi.RequestMetricsHook {
+	return c.MetricsHook
+}
+
+func (c *Configuration) SetMetrics(h openapi.RequestMetricsHook) {
+	c.MetricsHook = h
 }

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -459,4 +460,11 @@ func PlmnIdJsonToModels(plmnIdJson []byte) (*models.PlmnId, error) {
 		return nil, err
 	}
 	return &plmnId, nil
+}
+
+func getRespStatusCode(response *http.Response) int {
+	if response != nil {
+		return response.StatusCode
+	}
+	return 0
 }


### PR DESCRIPTION
#### Summary

This PR adds a hook mechanism that allow the NF to be able to retrieve information on outbound SBI calls.
#### Key Feature

- **Non-intrusive**: Minimal change in OpenAPI code
- **NF-Aware Metrics**: Allows each NF to track detailed SBI client metrics
- **Reusable Hook**: Any NF can implement its own metrics logic (a common function is used from the `util` package)

#### Example of use 

In a NF consumer, you can add in the configuration of the client the function you want to use to capture the metrics

```go
// internal/sbi/consumer/amf_service.go
configuration := Namf_Communication.NewConfiguration()  
configuration.SetBasePath(uri)  
configuration.SetMetrics(sbi_metrics.SbiMetricHook)  
client = Namf_Communication.NewAPIClient(configuration)
```
#### Integration 

All NFs will be updated to use this shared metrics utility to unify the monitoring approach.

This work is sponsored by [Free Mobile](https://mobile.free.fr/)!