### PR TITLE
client: fix nil-part panic in MultipartDeserialize on malformed body

### DIFF
--- a/client.go
+++ b/client.go
@@ -601,8 +601,7 @@ func MultipartDeserialize(b []byte, v interface{}, boundary string) (err error) 
 		var part, nextPart *multipart.Part
 		multipartBody := make([]byte, 1400)
 
-		// if no remain part, break this loop; propagate any other error (e.g. malformed
-		// boundary) rather than continuing with a nil *Part and panicking below.
+		// if no remain part, break this loop
 		nextPart, err = r.NextPart()
 		if err == io.EOF {
 			break

--- a/client.go
+++ b/client.go
@@ -601,17 +601,21 @@ func MultipartDeserialize(b []byte, v interface{}, boundary string) (err error) 
 		var part, nextPart *multipart.Part
 		multipartBody := make([]byte, 1400)
 
-		// if no remian part, break this loop
-		if nextPart, err = r.NextPart(); err == io.EOF {
+		// if no remain part, break this loop; propagate any other error (e.g. malformed
+		// boundary) rather than continuing with a nil *Part and panicking below.
+		nextPart, err = r.NextPart()
+		if err == io.EOF {
 			break
-		} else {
-			part = nextPart
 		}
+		if err != nil {
+			return fmt.Errorf("multipart NextPart: %w", err)
+		}
+		part = nextPart
 
 		contentType := part.Header.Get("Content-Type")
 		var n int
 		n, err = part.Read(multipartBody)
-		if err == nil {
+		if err != nil && err != io.EOF {
 			return err
 		}
 		multipartBody = multipartBody[:n]


### PR DESCRIPTION
Refs free5gc/free5gc#1026.

## Problem

`MultipartDeserialize` in `client.go` only checked `r.NextPart()` for `io.EOF`. When the declared `Content-Type: multipart/related` body is not valid MIME (missing/malformed boundary, truncated body, plain text, empty) `NextPart()` returns `(nil, err)`, and the subsequent `part.Header.Get("Content-Type")` dereferences nil and panics the handler goroutine.

Because the shared openapi client lives behind every NF's `MultipartRelatedBinding` path, an unauthenticated attacker reaching the SBI port (e.g. SMF's `POST /nsmf-pdusession/v1/sm-contexts`) can deterministically crash the handler with a single malformed POST.

## Fix

- Propagate non-EOF errors from `NextPart()` instead of dereferencing `nil`.
- Fix the inverted `part.Read` error check (was `if err == nil { return err }`) so a legitimate short read doesn't silently return a nil error and so unexpected read errors bubble up.

## Test

`go build ./...` and `go test ./...` clean. The package has no existing tests for `MultipartDeserialize`; happy to add a regression test here if maintainers prefer.