### PR TITLE
getContentID: reject empty multipart class discriminator instead of slice-panic

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,6 +253,14 @@ func getContentID(v reflect.Value, ref string, class string) (contentID string, 
 		if i := strings.IndexRune(fieldName, '-'); i != -1 {
 			fieldName = fieldName[:i]
 		}
+		// `fieldName` is client-controllable through a multipart class
+		// discriminator (e.g. n2InformationClass). An empty string ("") or a
+		// value starting with '-' would leave us slicing a zero-length string
+		// at fieldName[:1] / fieldName[1:] and panicked the multipart parse
+		// path on every SBI request that uses such a tag (#1039).
+		if len(fieldName) == 0 {
+			return "", fmt.Errorf("getContentID: empty class discriminator value")
+		}
 		fieldName = fieldName[:1] + strings.ToLower(fieldName[1:]) + "Info"
 		recursiveVal = lastVal.FieldByName(fieldName)
 		if recursiveVal.Kind() == reflect.Ptr {

--- a/client.go
+++ b/client.go
@@ -253,11 +253,6 @@ func getContentID(v reflect.Value, ref string, class string) (contentID string, 
 		if i := strings.IndexRune(fieldName, '-'); i != -1 {
 			fieldName = fieldName[:i]
 		}
-		// `fieldName` is client-controllable through a multipart class
-		// discriminator (e.g. n2InformationClass). An empty string ("") or a
-		// value starting with '-' would leave us slicing a zero-length string
-		// at fieldName[:1] / fieldName[1:] and panicked the multipart parse
-		// path on every SBI request that uses such a tag (#1039).
 		if len(fieldName) == 0 {
 			return "", fmt.Errorf("getContentID: empty class discriminator value")
 		}


### PR DESCRIPTION
Fixes free5gc/free5gc#1039.

`getContentID` constructs a Go field name from a multipart `class=` discriminator by slicing `fieldName[:1]`. When the resolved discriminator is an empty string — sent as `""` by the client, or trimmed to `""` by the dash-prefix handler at line 254 — the slice panics with `slice bounds out of range [:1] with length 0` and crashes any NF whose multipart deserialization path runs through this helper (AMF `N1N2MessageTransfer` and any other endpoint using a discriminator-derived Content-Id tag).

Reject the empty case with a clear error so callers see a 4xx instead of the NF crashing.