### PR TITLE
fix(openapi): guard non-struct kind in getContentID ref loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -267,9 +267,7 @@ func getContentID(v reflect.Value, ref string, class string) (contentID string, 
 	}
 
 	for _, part := range strings.Split(ref, ".") {
-		// Guard: FieldByName and Type().NumField() are only defined for struct kinds.
-		// A non-struct here means the ref path resolved to a leaf before all
-		// components were consumed. Fixes free5gc/free5gc#1040 and #1041.
+		// Guard against non-struct kinds; fixes free5gc/free5gc#1040 and #1041.
 		if !recursiveVal.IsValid() || recursiveVal.Kind() != reflect.Struct {
 			return "", fmt.Errorf(
 				"getContentID: ref %q: expected struct at component %q, got kind %v",

--- a/client.go
+++ b/client.go
@@ -267,6 +267,15 @@ func getContentID(v reflect.Value, ref string, class string) (contentID string, 
 	}
 
 	for _, part := range strings.Split(ref, ".") {
+		// Guard: FieldByName and Type().NumField() are only defined for struct kinds.
+		// A non-struct here means the ref path resolved to a leaf before all
+		// components were consumed. Fixes free5gc/free5gc#1040 and #1041.
+		if !recursiveVal.IsValid() || recursiveVal.Kind() != reflect.Struct {
+			return "", fmt.Errorf(
+				"getContentID: ref %q: expected struct at component %q, got kind %v",
+				ref, part, recursiveVal.Kind(),
+			)
+		}
 		lastValType := recursiveVal.Type()
 		listIndex := -1
 


### PR DESCRIPTION
Fixes free5gc/free5gc#1040 and free5gc/free5gc#1041.

FieldByName and Type().NumField() are only valid on struct kinds. A non-struct value at this point means the ref path resolved to a leaf before all components were consumed. Adding an IsValid+Kind guard at the top of the for loop prevents panics in all three FieldByName call sites within the loop body.