### PR TITLE
fix(oauth): reuse AccessToken API client to fix unbounded clientMap memory leak

### DIFF
--- a/oauth/get_token_context.go
+++ b/oauth/get_token_context.go
@@ -33,14 +33,18 @@ func sendAccTokenReq(
 ) (oauth2.TokenSource, *models.ProblemDetails, error) {
 	var client *AccessToken.APIClient
 
-	configuration := AccessToken.NewConfiguration()
-	configuration.SetBasePath(nrfUri)
-
-	if val, ok := clientMap.Load(configuration); ok {
+	// Cache the API client by the stable nrfUri. Previously the cache was keyed
+	// by the freshly-allocated *Configuration returned by NewConfiguration(),
+	// whose pointer differs on every call, so the lookup never hit and a new
+	// entry (each holding an *APIClient with its own http.Client) was stored on
+	// every token request, leaking unboundedly under SBI load.
+	if val, ok := clientMap.Load(nrfUri); ok {
 		client = val.(*AccessToken.APIClient)
 	} else {
+		configuration := AccessToken.NewConfiguration()
+		configuration.SetBasePath(nrfUri)
 		client = AccessToken.NewAPIClient(configuration)
-		clientMap.Store(configuration, client)
+		clientMap.Store(nrfUri, client)
 	}
 
 	var tok models.NrfAccessTokenAccessTokenRsp

--- a/oauth/get_token_context.go
+++ b/oauth/get_token_context.go
@@ -33,11 +33,6 @@ func sendAccTokenReq(
 ) (oauth2.TokenSource, *models.ProblemDetails, error) {
 	var client *AccessToken.APIClient
 
-	// Cache the API client by the stable nrfUri. Previously the cache was keyed
-	// by the freshly-allocated *Configuration returned by NewConfiguration(),
-	// whose pointer differs on every call, so the lookup never hit and a new
-	// entry (each holding an *APIClient with its own http.Client) was stored on
-	// every token request, leaking unboundedly under SBI load.
 	if val, ok := clientMap.Load(nrfUri); ok {
 		client = val.(*AccessToken.APIClient)
 	} else {


### PR DESCRIPTION
Summary:
oauth.sendAccTokenReq caches the AccessToken.APIClient in a package-level clientMap sync.Map, but keys the cache by the freshly-allocated `*Configuration` returned from `NewConfiguration()` on every call. Because that pointer is different on each invocation, the cache lookup never hits and a new entry (each holding an *AccessToken.APIClient with its own http.Client) is stored on every token request. The map only ever grows.

This is the root cause of free5gc/free5gc#1060.

Root cause:
oauth/get_token_context.go:
```
var clientMap sync.Map // package-level, never pruned

func sendAccTokenReq(...) (...) {
    configuration := AccessToken.NewConfiguration() // new *Configuration every call
    configuration.SetBasePath(nrfUri)

    if val, ok := clientMap.Load(configuration); ok { // key = ephemeral pointer -> always miss
        client = val.(*AccessToken.APIClient)
    } else {
        client = AccessToken.NewAPIClient(configuration)
        clientMap.Store(configuration, client) // new permanent entry on every request
    }
    ...
}
```
`NewConfiguration()` returns a `*Configuration`, so the map key is a distinct pointer on every call. tokenMap (keyed by the scope string) is fine and is correctly reused; only clientMap leaks.

Fix:
Key clientMap by the stable nrfUri string so the client is actually reused:
```
if val, ok := clientMap.Load(nrfUri); ok {
    client = val.(*AccessToken.APIClient)
} else {
    configuration := AccessToken.NewConfiguration()
    configuration.SetBasePath(nrfUri)
    client = AccessToken.NewAPIClient(configuration)
    clientMap.Store(nrfUri, client)
}
```